### PR TITLE
Remove "ñ" from Portuguese letters

### DIFF
--- a/algorithms/portuguese/stemmer.html
+++ b/algorithms/portuguese/stemmer.html
@@ -240,8 +240,7 @@ quiosqu<BR>
 <BR><BR>
 Letters in Portuguese include the following accented forms,
 <DL><DD>
-    <B><I>á  &nbsp;  é  &nbsp;  í  &nbsp;  ó  &nbsp;  ú  &nbsp;  â  &nbsp;  ê  &nbsp;  ô  &nbsp;  ç  &nbsp;  ã  &nbsp;  õ  &nbsp;  ü  &nbsp;
-    ñ</I></B>
+    <B><I>á  &nbsp;  é  &nbsp;  í  &nbsp;  ó  &nbsp;  ú  &nbsp;  â  &nbsp;  ê  &nbsp;  ô  &nbsp;  ç  &nbsp;  ã  &nbsp;  õ  &nbsp;  ü</I></B>
 </DL>
 The following letters are vowels:
 <DL><DD>


### PR DESCRIPTION
The (Spanish) letter "ñ" is not used in Portuguese. This was possibly a copy-paste typo.
