### PR TITLE
Ensure that output directory exists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,9 @@ Setup
 -----
 
 You'll need the Perl `Template Toolkit`, `neato` from `graphviz`, the
-`Closure Compiler` and `pngcrush` - on Debian you can install these with::
+`Closure Compiler`, `pngcrush` and `pygments` - on Debian you can install these with::
 
- apt-get install libtemplate-perl graphviz closure-compiler pngcrush
+ apt-get install libtemplate-perl graphviz closure-compiler pngcrush python-pygments
 
 You need the `pygments-snowball` repo as a subdirectory, for syntax highlighting
 Snowball code on the website:

--- a/generate
+++ b/generate
@@ -14,6 +14,7 @@ my $config = {
 };
 
 my $outpath = '../snowballstem.github.io/';
+print "Generating output in '$outpath'\n";
 
 $ENV{PYTHONPATH} = 'pygments-snowball';
 $ENV{PYTHONIOENCODING} = 'UTF-8';
@@ -22,6 +23,8 @@ my $code_path_prefix = 'code/';
 my $code_path_suffix = '.sbl';
 #my $code_path_prefix = '../snowball/algorithms/';
 #my $code_path_suffix = '/stem_Unicode.sbl';
+
+system("mkdir", "-p", $outpath) == 0 or die "Failed to ensure '$outpath' exists\n";
 
 # Stuff that just gets copied over.
 foreach my $f (qw(


### PR DESCRIPTION
Previously, the script would fail with an obscure error if the output
directory didn't exist.

Also, display the directory that the output is being generated in, to
avoid confusion.

Also, add more dependency information to README - I found that I needed
to install python-pygments on an ubuntu system to make the generation
work.
