### PR TITLE
Document changes to French stemmer re diaereses

### DIFF
--- a/algorithms/french/stemmer.tt
+++ b/algorithms/french/stemmer.tt
@@ -227,6 +227,12 @@ marking.)
 </p>
 
 <p>
+Replace <B><I>ë</I></B> and <B><I>ï</I></B> with <B><I>He</I></B> and <B><I>Hi</I></B>. The <B><I>H</I></B>
+marks the vowel as having originally had a diaeresis, while the vowel itself, lacking an accent, is able to
+match suffixes beginning in <B><I>e</I></B> or <B><I>i</I></B>.
+</p>
+
+<p>
 If the word begins with two vowels, <I>RV</I> is the region after the third
 letter, otherwise the region after the first vowel not at the beginning of
 the word, or the end of the word if these positions cannot be found. (Exceptionally,
@@ -347,7 +353,7 @@ Step 2<I>a</I>: Verb suffixes beginning <B><I>i</I></B>
 
 <DL><DD>
     Search for the longest among the following suffixes and if found,
-    delete if preceded by a non-vowel.
+    delete if the preceding character is neither a vowel nor <B><I>H</I></B>.
 <DL><DD>
         <B><I>îmes  &nbsp;  ît  &nbsp;  îtes  &nbsp;  i  &nbsp;  ie  &nbsp;  ies  &nbsp;  ir  &nbsp;  ira  &nbsp;  irai  &nbsp;  iraIent  &nbsp;  irais  &nbsp;  irait  &nbsp;  iras
          &nbsp;  irent  &nbsp;  irez  &nbsp;  iriez  &nbsp;  irions  &nbsp;  irons  &nbsp;  iront  &nbsp;  is  &nbsp;  issaIent  &nbsp;  issais  &nbsp;  issait
@@ -355,7 +361,7 @@ Step 2<I>a</I>: Verb suffixes beginning <B><I>i</I></B>
          &nbsp;  issions  &nbsp;  issons  &nbsp;  it</I></B>
 </DL>
 <BR>
-    (Note that the non-vowel itself must also be in <I>RV</I>.)
+    (Note that the preceding character itself must also be in <I>RV</I>.)
 </DL>
 
 <p>
@@ -407,7 +413,7 @@ Step 4: Residual suffix
 
 <DL><DD>
     <p>
-    If the word ends <B><I>s</I></B>, not preceded by <B><I>a</I></B>, <B><I>i</I></B>, <B><I>o</I></B>, <B><I>u</I></B>, <B><I>è</I></B> or <B><I>s</I></B>, delete it.
+    If the word ends <B><I>s</I></B>, not preceded by <B><I>a</I></B>, <B><I>i</I></B> (unless itself preceded by <B><I>H</I></B>), <B><I>o</I></B>, <B><I>u</I></B>, <B><I>è</I></B> or <B><I>s</I></B>, delete it.
     </p>
 
     <p>
@@ -426,8 +432,6 @@ Step 4: Residual suffix
         <DD>replace with <B><I>i</I></B>
     <DT><B><I>e</I></B>
         <DD>delete
-    <DT><B><I>ë</I></B>
-        <DD>if preceded by <B><I>gu</I></B>, delete
 </DL>
 <BR>
     (So note that <B><I>ion</I></B> is removed only when it is in <I>R</I>2 &#x2014; as well as being
@@ -460,7 +464,14 @@ And finally:
 </p>
 
 <DL><DD>
+    <p>
     Turn any remaining <B><I>I</I></B>, <B><I>U</I></B> and <B><I>Y</I></B> letters in the word back into lower case.
+    </p>
+
+    <p>
+    Turn <B><I>He</I></B> and <B><I>Hi</I></B> back into <B><I>ë</I></B> and <B><I>ï</I></B>, and remove any
+    remaining <B><I>H</I></B>.
+    </p>
 </DL>
 
 <h2>The same algorithm in Snowball</h2>

--- a/code/french.sbl
+++ b/code/french.sbl
@@ -42,6 +42,10 @@ define prelude as repeat goto (
            ('y' ] <- 'Y')
     )
     or
+    (  [ '{e"}' ] <- 'He' )
+    or
+    (  [ '{i"}' ] <- 'Hi' )
+    or
     (  ['y'] v <- 'Y' )
     or
     (  'q' ['u'] <- 'U' )
@@ -78,6 +82,9 @@ define postlude as repeat (
         'I' (<- 'i')
         'U' (<- 'u')
         'Y' (<- 'y')
+        'He' (<- '{e"}')
+        'Hi' (<- '{i"}')
+        'H' (delete)
         ''  (next)
     )
 )
@@ -167,7 +174,7 @@ backwardmode (
             'irions' 'irons' 'iront' 'is' 'issaIent' 'issais' 'issait'
             'issant' 'issante' 'issantes' 'issants' 'isse' 'issent' 'isses'
             'issez' 'issiez' 'issions' 'issons' 'it'
-                (non-v delete)
+                (not 'H' non-v delete)
         )
     )
 
@@ -196,14 +203,13 @@ backwardmode (
     define keep_with_s 'aiou{e`}s'
 
     define residual_suffix as (
-        try(['s'] test non-keep_with_s delete)
+        try(['s'] test ('Hi' or non-keep_with_s) delete)
         setlimit tomark pV for (
             [substring] among(
                 'ion'           (R2 's' or 't' delete)
                 'ier' 'i{e`}re'
                 'Ier' 'I{e`}re' (<-'i')
                 'e'             (delete)
-                '{e"}'          ('gu' delete)
             )
         )
     )


### PR DESCRIPTION
While making these changes, I found a couple of places in the documentation that rely on copying and pasting but could be automated. The Snowball code is taken from the code/ directory instead of being copied from ../snowball (though README.rst says otherwise). The sample vocabulary’s stemmed forms could be excerpted from ../snowball-data or generated by running the stemmer; as it is, they are liable to become unsynchronized.