### PR TITLE
Add Manticore Search to consumers list

### DIFF
--- a/projects.tt
+++ b/projects.tt
@@ -150,6 +150,11 @@ OpenFTS is an advanced PostgreSQL-based search engine, which supports using
 Snowball for stemming.
 </p>
 
+<h3><a href="https://manticoresearch.com/">Manticore Search</a></h3>
+<p>
+Manticore Search in an open source search server which supports stemming using Snowball.
+</p>
+
 <h2>Snowball support in other tools</h2>
 
 <p>


### PR DESCRIPTION
Manticore Search is a fork of Sphinx Search, which had support for Snowball for a long time.  We recently updated to Snowball 2.0.0.