### PR TITLE
Remove sexist "joke" from front page

### DIFF
--- a/index.tt
+++ b/index.tt
@@ -75,8 +75,6 @@ on how you can help.
 
 <blockquote>
 <p>
-Since it effectively provides a &#8216;<I>suffix STRIPPER GRAMmar</I>&#8217;, I had toyed with the
-idea of calling it &#8216;<I>strippergram</I>&#8217;, but good sense has prevailed, and so it is
 &#8216;<I>Snowball</I>&#8217; named as a tribute to SNOBOL, the excellent string handling language
 of Messrs Farber, Griswold, Poage and Polonsky from the 1960s.
 </p>


### PR DESCRIPTION
Making a "joke" about not naming the algorithm after a sex worker is both shaming to sex workers ("good sense prevailed") and stops people making contributions who find such things off-putting. It also makes no contribution ("I was thinking about onions at the time so I almost named it onion, but I didn't") aside from showing that the maintainers and contributors are fine with having a sexist joke on the web site.

As such, this patch removes it, leaving only relevant parts of the attributed quote.