### PR TITLE
Fix Swedish stopword

### DIFF
--- a/algorithms/swedish/stop.txt
+++ b/algorithms/swedish/stop.txt
@@ -112,7 +112,7 @@ vilka          | who, that
 ditt           | thy
 vem            | who
 vilket         | who, that
-sitta          | his
+sitt           | his
 sådana         | such a
 vart           | each
 dina           | thy


### PR DESCRIPTION
Correct the Swedish stop word for the "reflexive" 3rd person possessive pronoun.
The declinations of the pronoun are sin (sing. en.) sitt (sing. ett.) sina (pl. en and pl. ett).

Reference to Swedish academy dictionary:
https://svenska.se/tre/?sok=sitt
https://svenska.se/tre/?sok=sitta