### PR TITLE
Replace reference to "Enhancing a Greek language stemmer" PDF

### DIFF
--- a/algorithms/greek/stemmer.tt
+++ b/algorithms/greek/stemmer.tt
@@ -5,7 +5,7 @@
 <ul>
 [% algorithm_lis('greek', 'Greek') %]
 <li> <a href="https://sais.se/mthprize/2007/ntais2007.pdf">Ntais, Georgios. Development of a Stemmer for the Greek Language</a>
-<li> <a href="https://tampub.uta.fi/bitstream/handle/10024/80480/gradu03463.pdf">Saroukos, Spyridon. Enhancing a Greek language stemmer</a>
+<li> <a href="https://trepo.tuni.fi/bitstream/handle/10024/80480/gradu03463.pdf">Saroukos, Spyridon. Enhancing a Greek language stemmer</a>
 </ul>
 
 <p>This is an implementation of the stemmer described in: </p>


### PR DESCRIPTION
The old URL no longer works, and after a bit of searching, I found it in a new location.