### PR TITLE
Finnish: add common conjunction

### DIFF
--- a/algorithms/finnish/stop.txt
+++ b/algorithms/finnish/stop.txt
@@ -59,6 +59,7 @@ jotka  joiden        joita  joissa  joista  joihin joilla  joilta  joille  joina
 
 että   | that
 ja     | and
+joten  | so
 jos    | if
 koska  | because
 kuin   | than

--- a/algorithms/finnish/stop.txt
+++ b/algorithms/finnish/stop.txt
@@ -59,8 +59,8 @@ jotka  joiden        joita  joissa  joista  joihin joilla  joilta  joille  joina
 
 että   | that
 ja     | and
-joten  | so
 jos    | if
+joten  | so
 koska  | because
 kuin   | than
 mutta  | but


### PR DESCRIPTION
This PR proposes a tiny addition to the Finnish stopwords list. *joten* is a
very common conjunction in written Finnish, for example in Finnish Wikipedia it
appears in ~38,000 articles (exceeding several other conjunctions in this list).
Adding it is low risk, as it is not a homograph of another word.