### PR TITLE
docs(projects): list php-snowball as native PHP Snowball wrapper

### DIFF
--- a/projects.tt
+++ b/projects.tt
@@ -19,23 +19,28 @@ the Snowball-generated code, are well implemented, etc.  These projects aren't
 endorsed or recommended as such, but we hope they may be of interest.
 </p>
 
-<h3><a href="https://github.com/coral-media/php-snowball">PHP Snowball (native PHP extension)</a></h3>
+<h3><a href="https://coral-media.github.io/php-snowball">PHP Snowball (native PHP extension)</a></h3>
 
 <p>
-(added 2026) A native PHP extension providing bindings to the C implementation
-of Snowball (libstemmer). The extension exposes Snowball stemmers directly to PHP
-with minimal overhead and is designed for modern PHP runtimes. Compatible with PHP > 8.1.
+A native PHP extension providing bindings to the Snowball's C implementation. The extension exposes Snowball 
+stemmers directly to PHP with minimal overhead and is designed for modern PHP runtimes. 
+Compatible with PHP versions > 8.1.
 </p>
 
 <p>
-The extension is distributed using
+Distributed using
 <a href="https://github.com/php/pie">PIE</a>, the next-generation PHP extension
-installer, and can be installed with:
+installer. Windows users can download the pre-compiled extension from
+<a href="https://github.com/coral-media/php-snowball/releases">releases page</a>
 </p>
 
 <pre>
 pie install coral-media/php-snowball
 </pre>
+
+<p>
+Source Code: <a href="https://github.com/coral-media/php-snowball">
+</p>
 
 <h3><a href="https://github.com/tebeka/snowball">libstemmer in Go</a></h3>
 <p>

--- a/projects.tt
+++ b/projects.tt
@@ -19,19 +19,19 @@ the Snowball-generated code, are well implemented, etc.  These projects aren't
 endorsed or recommended as such, but we hope they may be of interest.
 </p>
 
-<h3><a href="https://coral-media.github.io/php-snowball">PHP Snowball (native PHP extension)</a></h3>
+<h3><a href="https://coral-media.github.io/php-snowball" target="_blank">PHP Snowball (native PHP extension)</a></h3>
 
 <p>
 A native PHP extension providing bindings to the Snowball's C implementation. The extension exposes Snowball 
 stemmers directly to PHP with minimal overhead and is designed for modern PHP runtimes. 
-Compatible with PHP versions > 8.1.
+Compatible with PHP versions &ge; 8.1.
 </p>
 
 <p>
 Distributed using
-<a href="https://github.com/php/pie">PIE</a>, the next-generation PHP extension
+<a href="https://github.com/php/pie" target="_blank">PIE</a>, the next-generation PHP extension
 installer. Windows users can download the pre-compiled extension from
-<a href="https://github.com/coral-media/php-snowball/releases">releases page</a>
+<a href="https://github.com/coral-media/php-snowball/releases" target="_blank">releases page</a>
 </p>
 
 <pre>
@@ -39,7 +39,7 @@ pie install coral-media/php-snowball
 </pre>
 
 <p>
-Source Code: <a href="https://github.com/coral-media/php-snowball">
+Source Code: <a href="https://github.com/coral-media/php-snowball" target="_blank">https://github.com/coral-media/php-snowball</a>
 </p>
 
 <h3><a href="https://github.com/tebeka/snowball">libstemmer in Go</a></h3>

--- a/projects.tt
+++ b/projects.tt
@@ -19,6 +19,24 @@ the Snowball-generated code, are well implemented, etc.  These projects aren't
 endorsed or recommended as such, but we hope they may be of interest.
 </p>
 
+<h3><a href="https://github.com/coral-media/php-snowball">PHP Snowball (native PHP extension)</a></h3>
+
+<p>
+(added 2026) A native PHP extension providing bindings to the C implementation
+of Snowball (libstemmer). The extension exposes Snowball stemmers directly to PHP
+with minimal overhead and is designed for modern PHP runtimes. Compatible with PHP > 8.1.
+</p>
+
+<p>
+The extension is distributed using
+<a href="https://github.com/php/pie">PIE</a>, the next-generation PHP extension
+installer, and can be installed with:
+</p>
+
+<pre>
+pie install coral-media/php-snowball
+</pre>
+
 <h3><a href="https://github.com/tebeka/snowball">libstemmer in Go</a></h3>
 <p>
 (added Feb 2013) Miki Tebeka has ported libstemmer_c to the Go programming


### PR DESCRIPTION
Hi, I added the libstemmer php native implementation.
The extension is not using Zephir or any other glue technique. Was written entirely in C and using the official snowball/libstemmer C distribution.
Its using the new PHP extension installer because PECL has been discontinued, still can be built from sources.
Windows users can download pre-compiled assets from the project repository releases page.
