### PR TITLE
Add Ukrainian algorithm documentation and web demo

### DIFF
--- a/algorithms/index.tt
+++ b/algorithms/index.tt
@@ -51,6 +51,7 @@ in parentheses:
     <li><a href="/algorithms/polish/stemmer.html">Polish</a></li>
     <li><a href="/algorithms/russian/stemmer.html">Russian</a></li>
     <li><a href="/algorithms/serbian/stemmer.html">Serbian</a></li>
+    <li><a href="/algorithms/ukrainian/stemmer.html">Ukrainian</a></li>
   </ul>
   <li><a href="/algorithms/arabic/stemmer.html">Arabic</a></li>
   <li><a href="/algorithms/armenian/stemmer.html">Armenian</a></li>

--- a/algorithms/ukrainian/stemmer.tt
+++ b/algorithms/ukrainian/stemmer.tt
@@ -1,0 +1,110 @@
+[% header('Ukrainian stemming algorithm') %]
+
+<h2>Links to resources</h2>
+
+<ul>
+[% algorithm_lis('ukrainian', 'Ukrainian', 'https://en.wikipedia.org/wiki/Ukrainian_language') %]
+</ul>
+
+<h2>Design Notes</h2>
+
+<p>
+The Ukrainian stemmer follows the general approach of the
+<a href="/algorithms/russian/stemmer.html">Russian stemmer</a>, adapted for
+Ukrainian morphology.  Ukrainian shares the Cyrillic alphabet with Russian but
+has additional letters (ґ, є, і, ї) and lacks some Russian letters (ё, ъ, ы, э).
+The apostrophe (&#x27;) plays an important orthographic role in Ukrainian,
+separating certain consonants from following soft vowels.
+</p>
+
+<h3>Regions</h3>
+
+<p>
+<b>pV</b> is defined as the region after the first vowel.  All suffix removal
+requires the suffix to be in pV, ensuring a minimum stem of at least one vowel.
+</p>
+
+<p>
+<b>R2</b> is the standard Snowball R2 region (the region after the second
+vowel-consonant sequence).  It is used to guard aggressive derivational suffix
+removal, preventing over-stemming of short words.  For example,
+<i>інформація</i> (information) stems to <i>інформ</i> because <i>-ація</i>
+falls in R2, but <i>акація</i> (acacia) only stems to <i>акаці</i> because
+<i>-ація</i> does not fall in R2 for this shorter word.
+</p>
+
+<h3>Suffix removal order</h3>
+
+<p>
+Suffixes are removed in this order:
+</p>
+
+<ol>
+<li>Perfective gerund (<i>-вши</i>, <i>-вшись</i>)</li>
+<li>Reflexive (<i>-ся</i>, <i>-сь</i>)</li>
+<li>Verbal noun (<i>-ання</i>, <i>-іння</i>, <i>-ення</i>)</li>
+<li>Professional (<i>-ельник</i>, <i>-ник</i>, <i>-ар</i>, etc.) or
+    Diminutive (<i>-очок</i>, <i>-ечок</i>, <i>-ик</i>, etc.)</li>
+<li>Adjective, verb, or noun endings</li>
+<li>Diminutive stem cleanup</li>
+<li>Professional suffixes (second pass)</li>
+<li>Derivational suffixes in R2</li>
+<li>Tidy-up (soft sign removal, superlative <i>-іш</i>, double <i>н</i>)</li>
+</ol>
+
+<h3>Professional before diminutive</h3>
+
+<p>
+Professional suffixes like <i>-ельник</i> are tried before diminutive suffixes
+like <i>-ик</i>.  Without this ordering, <i>будівельник</i> (builder) would
+match diminutive <i>-ик</i> first, giving stem <i>будівельн</i>.  With
+professional tried first, <i>-ельник</i> matches and gives <i>будів</i>,
+correctly grouping it with <i>будівництво</i> (construction) and
+<i>будівля</i> (building).
+</p>
+
+<h3>Compound derivational+inflectional suffixes</h3>
+
+<p>
+Rather than removing derivational and inflectional suffixes in separate passes
+(which can fail when an intermediate form matches another suffix group), we
+remove common compound patterns in a single step.  For example,
+<i>інформаційний</i> has compound suffix <i>-аційний</i> (derivational
+<i>-ацій</i> + inflectional <i>-ний</i>) which is removed as one unit to give
+stem <i>інформ</i>.  The compound patterns handled are:
+</p>
+
+<ul>
+<li><i>-аційн-</i> (інформаційний &rarr; інформ)</li>
+<li><i>-ічн-</i> / <i>-ичн-</i> (лінгвістичний &rarr; лінгвіст)</li>
+<li><i>-ійн-</i> (комерційний &rarr; комерц, традиційний &rarr; традиц)</li>
+<li><i>-уальн-</i> (інтелектуальний &rarr; інтелект)</li>
+<li><i>-онн-</i> (електронний &rarr; електр)</li>
+</ul>
+
+<p>
+These compound patterns are only removed in R2 to prevent over-stemming.
+</p>
+
+<h3>Apostrophe handling</h3>
+
+<p>
+The Ukrainian apostrophe separates consonants from softened vowels
+(e.g. <i>солов'ятко</i> &mdash; little nightingale).  The stemmer treats
+apostrophes as ordinary characters and does not remove them; tokenization
+or normalization before stemming should handle apostrophe variants if needed.
+</p>
+
+<h3>Superlative prefix</h3>
+
+<p>
+The superlative prefix <i>най-</i> is removed before suffix processing,
+so <i>найновіший</i> (newest) stems to <i>нов</i> via prefix removal +
+comparative <i>-іш</i> removal + adjective <i>-ий</i> removal.
+</p>
+
+<h2>The full algorithm in Snowball</h2>
+
+[% highlight_file('ukrainian') %]
+
+[% footer %]

--- a/code/ukrainian.sbl
+++ b/code/ukrainian.sbl
@@ -1,0 +1,477 @@
+stringescapes {}
+
+/* Ukrainian stemmer for Snowball
+ * Based on Ukrainian morphology analysis and dictionary research
+ *
+ * Primary source: "Словник мовних покручів" by Олекса Тихий (1964-1977)
+ * Additional analysis: Ukrainian morphology notes (internal)
+ *
+ * Key features:
+ * - Professional suffixes: -ар/-ник/-ач (каменяр, копач)
+ * - Verbal nouns: -ання/-яння/-іння (калякання, мурликання)
+ * - Rich diminutives: -еня/-атко (козеня, лисеня) + standard forms
+ * - Derivational: -ство/-ниця (козацтво, годувальниця)
+ * - Full noun/adjective/verb declension support
+ *
+ * Covers: nouns, adjectives, verbs, diminutives, verbal nouns, reflexives
+ */
+
+stringdef a    '{U+0430}'
+stringdef b    '{U+0431}'
+stringdef v    '{U+0432}'
+stringdef h    '{U+0433}'  // г
+stringdef g    '{U+0491}'  // ґ - Ukrainian specific
+stringdef d    '{U+0434}'
+stringdef e    '{U+0435}'
+stringdef ie   '{U+0454}'  // є - Ukrainian specific
+stringdef zh   '{U+0436}'
+stringdef z    '{U+0437}'
+stringdef y    '{U+0438}'  // и (not ы like in Russian)
+stringdef i    '{U+0456}'  // і - Ukrainian specific
+stringdef yi   '{U+0457}'  // ї - Ukrainian specific
+stringdef i`   '{U+0439}'  // й
+stringdef k    '{U+043A}'
+stringdef l    '{U+043B}'
+stringdef m    '{U+043C}'
+stringdef n    '{U+043D}'
+stringdef o    '{U+043E}'
+stringdef p    '{U+043F}'
+stringdef r    '{U+0440}'
+stringdef s    '{U+0441}'
+stringdef t    '{U+0442}'
+stringdef u    '{U+0443}'
+stringdef f    '{U+0444}'
+stringdef kh   '{U+0445}'
+stringdef ts   '{U+0446}'
+stringdef ch   '{U+0447}'
+stringdef sh   '{U+0448}'
+stringdef shch '{U+0449}'
+stringdef '    '{U+044C}'  // м'який знак (soft sign)
+stringdef iu   '{U+044E}'
+stringdef ia   '{U+044F}'
+
+
+routines ( mark_regions R2
+           perfective_gerund
+           reflexive
+           adjective
+           verb
+           noun
+           professional
+           diminutive
+           diminutive_stem
+           verbal_noun
+           derivational
+           tidy_up
+)
+
+externals ( stem )
+
+integers ( pV p2 )
+
+booleans ( found_diminutive found_professional )
+
+groupings ( v )
+
+define v '{a}{e}{y}{i}{o}{u}{ie}{yi}{iu}{ia}'
+
+define mark_regions as (
+    $pV = limit
+    $p2 = limit
+    do (
+        gopast v  setmark pV  gopast non-v
+        gopast v  gopast non-v  setmark p2
+    )
+)
+
+backwardmode (
+
+    define R2 as $p2 <= cursor
+
+    define perfective_gerund as (
+        [substring] among (
+            // Perfective gerunds (деепричастия доконаного виду)
+            // With {a}/{ia} prefix check
+            '{v}{sh}{y}'
+            '{v}{sh}{y}{s}{'}'
+                ('{a}' or '{ia}' delete)
+            // With {y} (и) - no prefix check needed (зробивши)
+            '{y}{v}{sh}{y}'
+            '{y}{v}{sh}{y}{s}{'}'
+                (delete)
+        )
+    )
+
+    define reflexive as (
+        [substring] among (
+            // Reflexive verb endings
+            '{t}{y}{s}{ia}' '{t}{y}{s}{'}'  // -тися/-тись (infinitive reflexive)
+            '{l}{a}{s}{'}'                  // -лась (past fem reflexive)
+            '{v}{s}{ia}' '{v}{s}{'}'        // -вся/-всь (past masc reflexive)
+            '{s}{ia}' '{s}{'}'              // -ся/-сь (generic reflexive)
+                (delete)
+        )
+    )
+
+    define adjective as (
+        [substring] among (
+            // Compound derivational+inflectional (longest first, R2-protected)
+            // These combine derivational suffix + case ending in one step
+            // e.g. інформаційний → інформ (not інформаційн)
+
+            // -аційн- (інформаційний, організаційний)
+            '{a}{ts}{i}{i`}{n}{y}{m}{y}'  // -аційними
+            '{a}{ts}{i}{i`}{n}{o}{h}{o}'  // -аційного
+            '{a}{ts}{i}{i`}{n}{o}{m}{u}'  // -аційному
+            '{a}{ts}{i}{i`}{n}{o}{iu}'    // -аційною
+            '{a}{ts}{i}{i`}{n}{o}{yi}'    // -аційної
+            '{a}{ts}{i}{i`}{n}{o}{i}'     // -аційної (alt)
+            '{a}{ts}{i}{i`}{n}{y}{kh}'    // -аційних
+            '{a}{ts}{i}{i`}{n}{y}{m}'     // -аційним
+            '{a}{ts}{i}{i`}{n}{y}{i`}'    // -аційний
+            '{a}{ts}{i}{i`}{n}{i}{i`}'    // -аційній
+            '{a}{ts}{i}{i`}{n}{a}'        // -аційна
+            '{a}{ts}{i}{i`}{n}{e}'        // -аційне
+            '{a}{ts}{i}{i`}{n}{i}'        // -аційні
+
+            // -ічн-/-ичн- (лінгвістичний, історичний, логічний)
+            '{i}{ch}{n}{y}{m}{y}'         // -ічними
+            '{i}{ch}{n}{o}{h}{o}'         // -ічного
+            '{i}{ch}{n}{o}{m}{u}'         // -ічному
+            '{i}{ch}{n}{o}{iu}'           // -ічною
+            '{i}{ch}{n}{o}{yi}'           // -ічної
+            '{i}{ch}{n}{o}{i}'            // -ічної (alt)
+            '{i}{ch}{n}{y}{kh}'           // -ічних
+            '{i}{ch}{n}{y}{m}'            // -ічним
+            '{i}{ch}{n}{y}{i`}'           // -ічний
+            '{i}{ch}{n}{i}{i`}'           // -ічній
+            '{i}{ch}{n}{a}'               // -ічна
+            '{i}{ch}{n}{e}'               // -ічне
+            '{i}{ch}{n}{i}'               // -ічні
+            '{y}{ch}{n}{y}{m}{y}'         // -ичними
+            '{y}{ch}{n}{o}{h}{o}'         // -ичного
+            '{y}{ch}{n}{o}{m}{u}'         // -ичному
+            '{y}{ch}{n}{o}{iu}'           // -ичною
+            '{y}{ch}{n}{o}{yi}'           // -ичної
+            '{y}{ch}{n}{o}{i}'            // -ичної (alt)
+            '{y}{ch}{n}{y}{kh}'           // -ичних
+            '{y}{ch}{n}{y}{m}'            // -ичним
+            '{y}{ch}{n}{y}{i`}'           // -ичний
+            '{y}{ch}{n}{i}{i`}'           // -ичній
+            '{y}{ch}{n}{a}'               // -ична
+            '{y}{ch}{n}{e}'               // -ичне
+            '{y}{ch}{n}{i}'               // -ичні
+
+            // -ійн- (комерційний, традиційний)
+            '{i}{i`}{n}{y}{m}{y}'         // -ійними
+            '{i}{i`}{n}{o}{h}{o}'         // -ійного
+            '{i}{i`}{n}{o}{m}{u}'         // -ійному
+            '{i}{i`}{n}{o}{iu}'           // -ійною
+            '{i}{i`}{n}{o}{yi}'           // -ійної
+            '{i}{i`}{n}{o}{i}'            // -ійної (alt)
+            '{i}{i`}{n}{y}{kh}'           // -ійних
+            '{i}{i`}{n}{y}{m}'            // -ійним
+            '{i}{i`}{n}{y}{i`}'           // -ійний
+            '{i}{i`}{n}{i}{i`}'           // -ійній
+            '{i}{i`}{n}{a}'               // -ійна
+            '{i}{i`}{n}{e}'               // -ійне
+            '{i}{i`}{n}{i}'               // -ійні
+
+            // -уальн- (інтелектуальний, віртуальний, актуальний)
+            '{u}{a}{l}{'}{n}{y}{m}{y}'    // -уальними
+            '{u}{a}{l}{'}{n}{o}{h}{o}'    // -уального
+            '{u}{a}{l}{'}{n}{o}{m}{u}'    // -уальному
+            '{u}{a}{l}{'}{n}{o}{iu}'      // -уальною
+            '{u}{a}{l}{'}{n}{o}{yi}'      // -уальної
+            '{u}{a}{l}{'}{n}{o}{i}'       // -уальної (alt)
+            '{u}{a}{l}{'}{n}{y}{kh}'      // -уальних
+            '{u}{a}{l}{'}{n}{y}{m}'       // -уальним
+            '{u}{a}{l}{'}{n}{y}{i`}'      // -уальний
+            '{u}{a}{l}{'}{n}{i}{i`}'      // -уальній
+            '{u}{a}{l}{'}{n}{a}'          // -уальна
+            '{u}{a}{l}{'}{n}{e}'          // -уальне
+            '{u}{a}{l}{'}{n}{i}'          // -уальні
+
+            // -онн- (електронний, нейронний)
+            '{o}{n}{n}{y}{m}{y}'          // -онними
+            '{o}{n}{n}{o}{h}{o}'          // -онного
+            '{o}{n}{n}{o}{m}{u}'          // -онному
+            '{o}{n}{n}{o}{iu}'            // -онною
+            '{o}{n}{n}{o}{yi}'            // -онної
+            '{o}{n}{n}{o}{i}'             // -онної (alt)
+            '{o}{n}{n}{y}{kh}'            // -онних
+            '{o}{n}{n}{y}{m}'             // -онним
+            '{o}{n}{n}{y}{i`}'            // -онний
+            '{o}{n}{n}{i}{i`}'            // -онній
+            '{o}{n}{n}{a}'                // -онна
+            '{o}{n}{n}{e}'                // -онне
+            '{o}{n}{n}{i}'                // -онні
+                (R2 delete)
+
+            // -аці- noun forms (інформація, організація — tried here before verb -ію intercepts)
+            '{a}{ts}{i}{ia}{m}{y}'        // -аціями
+            '{a}{ts}{i}{ia}{kh}'          // -аціях
+            '{a}{ts}{i}{ia}{m}'           // -аціям
+            '{a}{ts}{i}{ie}{iu}'          // -аціє́ю (inst)
+            '{a}{ts}{i}{iu}'              // -ацію
+            '{a}{ts}{i}{ia}'              // -ація
+            '{a}{ts}{i}{yi}'              // -ації (gen/dat/loc — ї=U+0457)
+                (R2 delete)
+
+            // Participles (longest first - verbal adjectives)
+            '{o}{v}{a}{n}{y}{i`}' '{u}{v}{a}{n}{y}{i`}'  // -ований/-уваний
+            '{o}{v}{a}{n}{a}' '{u}{v}{a}{n}{a}'           // -ована/-увана
+            '{o}{v}{a}{n}{e}' '{u}{v}{a}{n}{e}'           // -оване/-уване
+            '{o}{v}{a}{n}{i}' '{u}{v}{a}{n}{i}'           // -овані/-увані
+            '{o}{v}{a}{n}{o}' '{u}{v}{a}{n}{o}'           // -овано/-увано
+            '{u}{ch}{y}{i`}' '{iu}{ch}{y}{i`}'            // -учий/-ючий
+            '{u}{ch}{a}' '{iu}{ch}{a}'                    // -уча/-юча
+            '{u}{ch}{e}' '{iu}{ch}{e}'                    // -уче/-юче
+            '{u}{ch}{i}' '{iu}{ch}{i}'                    // -учі/-ючі
+            '{v}{sh}{y}{i`}'                               // -вший
+
+            // Longest standard endings first
+            '{yi}{m}{y}' '{i}{m}{y}' '{y}{m}{y}'    // Instrumental plural
+            '{'}{'}{o}{yi}' '{'}{'}{o}{i}'          // Genitive singular fem (soft)
+            '{'}{'}{o}{h}{o}'                       // Genitive singular masc/neut (soft)
+            '{'}{'}{o}{m}{u}'                       // Dative singular masc/neut (soft)
+            '{'}{'}{o}{iu}'                         // Instrumental singular fem (soft)
+            '{ie}{h}{o}' '{o}{h}{o}'                // Genitive singular masc/neut
+            '{o}{yi}' '{o}{i}'                      // Genitive singular fem
+            '{o}{m}{u}'                             // Dative singular masc/neut
+            '{o}{iu}'                               // Instrumental singular fem
+            '{yi}{kh}' '{i}{kh}' '{y}{kh}'          // Genitive/Locative plural
+            '{yi}{m}' '{i}{m}' '{y}{m}'             // Dative plural
+            '{i}{i`}'                               // Dative/Locative singular fem
+            '{y}{i`}'                               // Nominative singular masc
+            '{o}{i`}'                               // Various
+                (delete)  // standard adjective endings (no R2 needed)
+        )
+    )
+
+    define verb as (
+        [substring] among (
+            // Longest endings first
+            '{a}{t}{y}' '{i}{t}{y}'         // Infinitive (читати→чит, робити→роб)
+            '{y}{t}{y}'                     // Infinitive (робити with и)
+            '{a}{v}' '{i}{v}'               // Past masc (читав→чит, робів→роб)
+            '{y}{v}'                        // Past masc (робив→роб)
+            '{a}{iu}' '{i}{iu}'             // Present 1st sg
+            '{iu}{t}{'}'  '{u}{t}{'}'       // Present 3rd pl
+            '{a}{iu}{t}{'}'                 // Present 3rd pl variant
+            '{ie}{m}{o}' '{i}{m}{o}'        // Present 1st pl
+            '{y}{m}{o}'                     // Present 1st pl (робимо)
+            '{ie}{t}{e}' '{i}{t}{e}'        // Present 2nd pl
+            '{y}{t}{e}'                     // Present 2nd pl (робите)
+            '{i`}{t}{e}'                    // Imperative pl variant
+            '{ie}{m}' '{i}{m}'              // Present 1st pl short
+            '{y}{m}'                        // Present 1st pl short (робим)
+            '{l}{a}' '{l}{y}' '{l}{o}'      // Past tense (others)
+            '{t}{y}'                        // Infinitive (fallback)
+            '{ie}{sh}' '{y}{sh}'            // Present 2nd sg
+            '{ie}'                          // Present 3rd sg/future
+            '{i`}'                          // Imperative sg
+            '{iu}' '{u}'                    // Present 1st sg (fallback)
+            '{v}'                           // Past masc (fallback)
+                (delete)
+        )
+    )
+
+    define noun as (
+        [substring] among (
+            // Collective/abstract nouns (specific, safe without R2)
+            '{s}{t}{v}{o}'            // -ство (багатство→багат)
+            '{t}{v}{o}'              // -тво (words in -цтво like козацтво match -ство above)
+
+            // Longest plural endings first
+            '{ia}{m}{y}' '{a}{m}{y}'        // Instrumental plural
+            '{ia}{kh}' '{a}{kh}'            // Locative plural
+            '{ia}{m}' '{a}{m}'              // Dative plural
+            '{i}{v}' '{e}{v}' '{e}{i`}'     // Genitive plural masc
+
+            // Singular specific endings
+            '{o}{v}{i}'                      // -ові (братові→брат)
+            '{e}{v}{i}'
+            // Instrumental singular
+            '{ie}{m}' '{e}{m}' '{o}{m}'
+            '{ie}{iu}' '{e}{iu}' '{o}{iu}'
+
+            // Shorter endings
+            '{ia}' '{a}' '{u}' '{iu}' '{i}' '{yi}' '{y}' '{e}' '{ie}' '{o}'
+                (delete)
+        )
+    )
+
+    define professional as (
+        [substring] among (
+            '{i}{v}{n}{y}{k}'  '{a}{l}{'}{n}{y}{k}'  '{e}{l}{'}{n}{y}{k}'  // -івник, -альник, -ельник
+            '{ia}{r}' '{a}{r}'  // -яр, -ар (каменяр)
+            '{n}{y}{k}'         // -ник (generic agent)
+            '{a}{ch}'           // -ач (копач)
+                (delete)
+        )
+    )
+
+    define diminutive as (
+        [substring] among (
+            // Double diminutives (longest first)
+            '{o}{ch}{e}{ch}{o}{k}' '{o}{ch}{e}{ch}{k}{a}' '{o}{ch}{e}{ch}{k}{y}' '{o}{ch}{e}{ch}{k}{o}' '{o}{ch}{e}{ch}{k}{i}'
+
+            // Animal young (from dictionary analysis)
+            '{i}{t}{k}{o}'         // -ітко (собаченітко → собачен)
+            '{ia}{t}{k}{o}'        // -ятко (солов'ятко → солов, соколенятко → соколен)
+            '{a}{t}{k}{o}'         // -атко (babies)
+
+            // Most diminutive forms
+            '{o}{ch}{o}{k}' '{o}{ch}{k}{a}' '{o}{ch}{k}{y}' '{o}{ch}{k}{o}' '{o}{ch}{k}{i}'
+            '{e}{ch}{o}{k}' '{e}{ch}{k}{a}' '{e}{ch}{k}{y}' '{e}{ch}{k}{o}' '{e}{ch}{k}{i}'
+            '{i}{ch}{o}{k}' '{i}{ch}{k}{a}' '{i}{ch}{k}{y}' '{i}{ch}{k}{o}' '{i}{ch}{k}{i}'
+
+            // Intensive diminutives (longest first)
+            '{e}{s}{e}{n}{'}{k}{a}' '{e}{s}{e}{n}{'}{k}{y}' '{e}{s}{e}{n}{'}{k}{o}' '{e}{s}{e}{n}{'}{k}{i}'  // -есеньк-
+            '{i}{s}{i}{n}{'}{k}{a}' '{i}{s}{i}{n}{'}{k}{y}' '{i}{s}{i}{n}{'}{k}{o}' '{i}{s}{i}{n}{'}{k}{i}'  // -ісіньк-
+            '{iu}{s}{i}{n}{'}{k}{a}' '{iu}{s}{i}{n}{'}{k}{y}' '{iu}{s}{i}{n}{'}{k}{o}' '{iu}{s}{i}{n}{'}{k}{i}'  // -юсіньк-
+            '{o}{n}{'}{k}{a}' '{o}{n}{'}{k}{y}' '{o}{n}{'}{k}{o}' '{o}{n}{'}{k}{i}'  // -оньк-
+
+            // Regular -еньк-, -іньк- patterns
+            '{e}{n}{'}{k}{u}'
+            '{e}{n}{'}{k}{a}' '{e}{n}{'}{k}{y}' '{e}{n}{'}{k}{o}' '{e}{n}{'}{k}{i}'
+            '{i}{n}{'}{k}{a}' '{i}{n}{'}{k}{y}' '{i}{n}{'}{k}{o}' '{i}{n}{'}{k}{i}'
+
+            // Animal young (shorter forms)
+            '{e}{n}{ia}'  // -еня (козеня, лисеня)
+
+            // Short diminutives (3+ chars to avoid conflicts with regular nouns)
+            '{ch}{y}{k}'          // -чик (хлопчик)
+            '{y}{n}{k}{a}' '{i}{n}{k}{a}'  // -инка/-інка (дівчинка)
+            '{u}{s}{'}'  '{i}{s}{'}'  '{o}{s}{'}'
+            '{u}{n}{'}'  '{i}{n}{'}'  '{e}{n}{'}'
+            // 2-char: -ик/-ік/-ок safe (few non-diminutive nouns end with these)
+            // NOT -ка/-ко (too common as regular noun endings)
+            '{y}{k}' '{i}{k}' '{o}{k}'
+                (delete)
+        )
+    )
+
+    define diminutive_stem as (
+        [substring] among (
+            '{e}{s}{e}{n}{'}{k}'  // -есеньк
+            '{i}{s}{i}{n}{'}{k}'  // -ісіньк
+            '{iu}{s}{i}{n}{'}{k}' // -юсіньк
+            '{o}{ch}{e}{ch}'      // -очеч
+            '{e}{n}{'}{k}'        // -еньк
+            '{o}{n}{'}{k}'        // -оньк
+            '{i}{n}{'}{k}'        // -іньк
+            '{i}{t}{k}'           // -ітк
+            '{a}{t}{k}'           // -атк
+            // Note: -ятк intentionally excluded — it occurs in stems
+            // like десятк(а), пам'ятк(а), початк(ів); -ятко is handled
+            // as a whole in the diminutive section above
+                (delete)
+        )
+    )
+
+    define verbal_noun as (
+        [substring] R2 among (
+            // Verbal nouns — R2 required to protect short words like
+            // мигтіння, боління, бродіння from over-stemming
+            '{a}{n}{n}{ia}'        // -ання
+            '{ia}{n}{n}{ia}'       // -яння
+            '{i}{n}{n}{ia}'        // -іння
+            '{e}{n}{n}{ia}'        // -ення
+                (delete)
+        )
+    )
+
+    define derivational as (
+        [substring] R2 among (
+            // Derivational suffixes (only in R2 region!)
+            '{i}{z}{a}{ts}{i}{ia}'  // -ізація
+            '{a}{ts}{i}{ia}'        // -ація
+            '{i}{v}{shch}{y}{n}{a}' // -івщина (бабівщина → баб)
+
+            // Place/female forms
+            '{a}{r}{n}{ia}'       // -арня
+            '{i}{v}{n}{ia}'       // -івня
+            '{n}{y}{ts}{ia}'      // -ниця
+
+            // Collective/abstract
+            '{ts}{t}{v}{o}'       // -цтво
+            '{s}{t}{v}{o}'        // -ство
+
+            // Quality/abstract
+            '{n}{i}{s}{t}{'}'     // -ність
+            '{o}{v}{i}{s}{t}{'}'  // -овість
+            '{i}{s}{t}{'}'        // -ість
+
+            // Adjectival derivational
+            '{e}{l}{'}{n}'        // -ельн (кахельний → кахел after adj -ий)
+            '{l}{'}{n}'           // -льн (кахльний → кахл)
+            '{s}{'}{k}'           // -ськ (козацький → козац)
+            '{z}{'}{k}'           // -зьк
+            '{u}{v}{a}{t}'        // -уват
+            '{o}{v}{a}{t}'        // -оват
+            '{i}{v}{n}'           // -івн (пасічниківна → пасічник)
+            '{o}{v}'              // -ов (дощовий → дощ after adj -ий)
+            '{ia}{n}'             // -ян (кахляний → кахл after adj -ий)
+
+            // Other
+            '{i}{z}{m}'           // -ізм
+            '{i}{s}{t}'           // -іст
+            '{y}{shch}'           // -ищ
+                (delete)
+        )
+    )
+
+    define tidy_up as (
+        [substring] among (
+            // Superlative/comparative forms
+            '{i}{sh}'
+               (delete
+                ['{n}'] '{n}' delete
+               )
+            // Consonant alternations in verbs
+            '{l}'
+               ('{b}' or '{p}' or '{v}' or '{m}' delete)
+            // Double consonants
+            '{n}'
+               ('{n}' delete)
+            // Soft sign cleanup
+            '{'}'
+               (delete)
+        )
+    )
+)
+
+define stem as (
+    // Strip най- prefix (superlative)
+    do (
+        ['{n}{a}{i`}'] delete
+    )
+    unset found_diminutive
+    unset found_professional
+    do mark_regions
+    backwards setlimit tomark pV for (
+        do (
+             perfective_gerund or
+             ( try reflexive
+               ( verbal_noun or
+                 ( try ( ( professional (set found_professional) )
+                         or ( diminutive (set found_diminutive) ) )
+                   not found_professional ( adjective or verb or noun )
+                 )
+               )
+             )
+        )
+        // Diminutive stems (after adjective endings removed)
+        try ( diminutive_stem (set found_diminutive) )
+
+        // Professional suffixes (after noun declension removed)
+        // Skip if diminutive already fired (prevents -ач removal on собач- from собаченітко)
+        not found_diminutive not found_professional try professional
+
+        // Derivational suffixes (in R2 only)
+        do derivational
+        do tidy_up
+    )
+)

--- a/index.tt
+++ b/index.tt
@@ -119,6 +119,9 @@ speedily, and in any case they reserve the right to post their answers on snowba
 
 <ul>
   <li>
+    <strong>Jan 2026</strong> - Ukrainian stemming algorithm contributed by Dmitry Prudnikov.
+  </li>
+  <li>
     <strong>Oct 2025</strong> - Polish stemming algorithm contributed by Dmitry Shachnev.
   </li>
   <li>

--- a/js/ukrainian-stemmer.js
+++ b/js/ukrainian-stemmer.js
@@ -1,0 +1,702 @@
+// Generated from ukrainian.sbl by Snowball 3.0.0 - https://snowballstem.org/
+
+// deno-lint-ignore-file ban-unused-ignore no-constant-condition no-empty prefer-const
+
+const a_0 = [
+    ["\u0432\u0448\u0438", -1, 1],
+    ["\u0438\u0432\u0448\u0438", 0, 2],
+    ["\u0432\u0448\u0438\u0441\u044C", -1, 1],
+    ["\u0438\u0432\u0448\u0438\u0441\u044C", 2, 2]
+];
+
+const a_1 = [
+    ["\u0441\u044C", -1, 1],
+    ["\u043B\u0430\u0441\u044C", 0, 1],
+    ["\u0432\u0441\u044C", 0, 1],
+    ["\u0442\u0438\u0441\u044C", 0, 1],
+    ["\u0441\u044F", -1, 1],
+    ["\u0432\u0441\u044F", 4, 1],
+    ["\u0442\u0438\u0441\u044F", 4, 1]
+];
+
+const a_2 = [
+    ["\u043E\u0432\u0430\u043D\u0430", -1, 2],
+    ["\u0443\u0432\u0430\u043D\u0430", -1, 2],
+    ["\u0456\u0439\u043D\u0430", -1, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u0430", 2, 1],
+    ["\u043E\u043D\u043D\u0430", -1, 1],
+    ["\u0438\u0447\u043D\u0430", -1, 1],
+    ["\u0456\u0447\u043D\u0430", -1, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u0430", -1, 1],
+    ["\u0443\u0447\u0430", -1, 2],
+    ["\u044E\u0447\u0430", -1, 2],
+    ["\u043E\u0432\u0430\u043D\u0435", -1, 2],
+    ["\u0443\u0432\u0430\u043D\u0435", -1, 2],
+    ["\u0456\u0439\u043D\u0435", -1, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u0435", 12, 1],
+    ["\u043E\u043D\u043D\u0435", -1, 1],
+    ["\u0438\u0447\u043D\u0435", -1, 1],
+    ["\u0456\u0447\u043D\u0435", -1, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u0435", -1, 1],
+    ["\u0443\u0447\u0435", -1, 2],
+    ["\u044E\u0447\u0435", -1, 2],
+    ["\u0438\u043C\u0438", -1, 2],
+    ["\u0456\u0439\u043D\u0438\u043C\u0438", 20, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u0438\u043C\u0438", 21, 1],
+    ["\u043E\u043D\u043D\u0438\u043C\u0438", 20, 1],
+    ["\u0438\u0447\u043D\u0438\u043C\u0438", 20, 1],
+    ["\u0456\u0447\u043D\u0438\u043C\u0438", 20, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u0438\u043C\u0438", 20, 1],
+    ["\u0430\u0446\u0456\u044F\u043C\u0438", -1, 1],
+    ["\u0456\u043C\u0438", -1, 2],
+    ["\u0457\u043C\u0438", -1, 2],
+    ["\u0438\u0439", -1, 2],
+    ["\u043E\u0432\u0430\u043D\u0438\u0439", 30, 2],
+    ["\u0443\u0432\u0430\u043D\u0438\u0439", 30, 2],
+    ["\u0456\u0439\u043D\u0438\u0439", 30, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u0438\u0439", 33, 1],
+    ["\u043E\u043D\u043D\u0438\u0439", 30, 1],
+    ["\u0438\u0447\u043D\u0438\u0439", 30, 1],
+    ["\u0456\u0447\u043D\u0438\u0439", 30, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u0438\u0439", 30, 1],
+    ["\u0443\u0447\u0438\u0439", 30, 2],
+    ["\u044E\u0447\u0438\u0439", 30, 2],
+    ["\u0432\u0448\u0438\u0439", 30, 2],
+    ["\u043E\u0439", -1, 2],
+    ["\u0456\u0439", -1, 2],
+    ["\u0456\u0439\u043D\u0456\u0439", 43, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u0456\u0439", 44, 1],
+    ["\u043E\u043D\u043D\u0456\u0439", 43, 1],
+    ["\u0438\u0447\u043D\u0456\u0439", 43, 1],
+    ["\u0456\u0447\u043D\u0456\u0439", 43, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u0456\u0439", 43, 1],
+    ["\u0438\u043C", -1, 2],
+    ["\u0456\u0439\u043D\u0438\u043C", 50, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u0438\u043C", 51, 1],
+    ["\u043E\u043D\u043D\u0438\u043C", 50, 1],
+    ["\u0438\u0447\u043D\u0438\u043C", 50, 1],
+    ["\u0456\u0447\u043D\u0438\u043C", 50, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u0438\u043C", 50, 1],
+    ["\u0430\u0446\u0456\u044F\u043C", -1, 1],
+    ["\u0456\u043C", -1, 2],
+    ["\u0457\u043C", -1, 2],
+    ["\u043E\u0433\u043E", -1, 2],
+    ["\u0456\u0439\u043D\u043E\u0433\u043E", 60, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u043E\u0433\u043E", 61, 1],
+    ["\u043E\u043D\u043D\u043E\u0433\u043E", 60, 1],
+    ["\u0438\u0447\u043D\u043E\u0433\u043E", 60, 1],
+    ["\u0456\u0447\u043D\u043E\u0433\u043E", 60, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u043E\u0433\u043E", 60, 1],
+    ["\u044C\u044C\u043E\u0433\u043E", 60, 2],
+    ["\u0454\u0433\u043E", -1, 2],
+    ["\u043E\u0432\u0430\u043D\u043E", -1, 2],
+    ["\u0443\u0432\u0430\u043D\u043E", -1, 2],
+    ["\u043E\u043C\u0443", -1, 2],
+    ["\u0456\u0439\u043D\u043E\u043C\u0443", 71, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u043E\u043C\u0443", 72, 1],
+    ["\u043E\u043D\u043D\u043E\u043C\u0443", 71, 1],
+    ["\u0438\u0447\u043D\u043E\u043C\u0443", 71, 1],
+    ["\u0456\u0447\u043D\u043E\u043C\u0443", 71, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u043E\u043C\u0443", 71, 1],
+    ["\u044C\u044C\u043E\u043C\u0443", 71, 2],
+    ["\u0438\u0445", -1, 2],
+    ["\u0456\u0439\u043D\u0438\u0445", 79, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u0438\u0445", 80, 1],
+    ["\u043E\u043D\u043D\u0438\u0445", 79, 1],
+    ["\u0438\u0447\u043D\u0438\u0445", 79, 1],
+    ["\u0456\u0447\u043D\u0438\u0445", 79, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u0438\u0445", 79, 1],
+    ["\u0430\u0446\u0456\u044F\u0445", -1, 1],
+    ["\u0456\u0445", -1, 2],
+    ["\u0457\u0445", -1, 2],
+    ["\u043E\u044E", -1, 2],
+    ["\u0456\u0439\u043D\u043E\u044E", 89, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u043E\u044E", 90, 1],
+    ["\u043E\u043D\u043D\u043E\u044E", 89, 1],
+    ["\u0438\u0447\u043D\u043E\u044E", 89, 1],
+    ["\u0456\u0447\u043D\u043E\u044E", 89, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u043E\u044E", 89, 1],
+    ["\u044C\u044C\u043E\u044E", 89, 2],
+    ["\u0430\u0446\u0456\u0454\u044E", -1, 1],
+    ["\u0430\u0446\u0456\u044E", -1, 1],
+    ["\u0430\u0446\u0456\u044F", -1, 1],
+    ["\u043E\u0432\u0430\u043D\u0456", -1, 2],
+    ["\u0443\u0432\u0430\u043D\u0456", -1, 2],
+    ["\u0456\u0439\u043D\u0456", -1, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u0456", 102, 1],
+    ["\u043E\u043D\u043D\u0456", -1, 1],
+    ["\u0438\u0447\u043D\u0456", -1, 1],
+    ["\u0456\u0447\u043D\u0456", -1, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u0456", -1, 1],
+    ["\u043E\u0456", -1, 2],
+    ["\u0456\u0439\u043D\u043E\u0456", 108, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u043E\u0456", 109, 1],
+    ["\u043E\u043D\u043D\u043E\u0456", 108, 1],
+    ["\u0438\u0447\u043D\u043E\u0456", 108, 1],
+    ["\u0456\u0447\u043D\u043E\u0456", 108, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u043E\u0456", 108, 1],
+    ["\u044C\u044C\u043E\u0456", 108, 2],
+    ["\u0443\u0447\u0456", -1, 2],
+    ["\u044E\u0447\u0456", -1, 2],
+    ["\u043E\u0457", -1, 2],
+    ["\u0456\u0439\u043D\u043E\u0457", 118, 1],
+    ["\u0430\u0446\u0456\u0439\u043D\u043E\u0457", 119, 1],
+    ["\u043E\u043D\u043D\u043E\u0457", 118, 1],
+    ["\u0438\u0447\u043D\u043E\u0457", 118, 1],
+    ["\u0456\u0447\u043D\u043E\u0457", 118, 1],
+    ["\u0443\u0430\u043B\u044C\u043D\u043E\u0457", 118, 1],
+    ["\u044C\u044C\u043E\u0457", 118, 2],
+    ["\u0430\u0446\u0456\u0457", -1, 1]
+];
+
+const a_3 = [
+    ["\u043B\u0430", -1, 1],
+    ["\u0432", -1, 1],
+    ["\u0430\u0432", 1, 1],
+    ["\u0438\u0432", 1, 1],
+    ["\u0456\u0432", 1, 1],
+    ["\u0438\u0442\u0435", -1, 1],
+    ["\u0439\u0442\u0435", -1, 1],
+    ["\u0454\u0442\u0435", -1, 1],
+    ["\u0456\u0442\u0435", -1, 1],
+    ["\u043B\u0438", -1, 1],
+    ["\u0442\u0438", -1, 1],
+    ["\u0430\u0442\u0438", 10, 1],
+    ["\u0438\u0442\u0438", 10, 1],
+    ["\u0456\u0442\u0438", 10, 1],
+    ["\u0439", -1, 1],
+    ["\u0438\u043C", -1, 1],
+    ["\u0454\u043C", -1, 1],
+    ["\u0456\u043C", -1, 1],
+    ["\u043B\u043E", -1, 1],
+    ["\u0438\u043C\u043E", -1, 1],
+    ["\u0454\u043C\u043E", -1, 1],
+    ["\u0456\u043C\u043E", -1, 1],
+    ["\u0443", -1, 1],
+    ["\u0438\u0448", -1, 1],
+    ["\u0454\u0448", -1, 1],
+    ["\u0443\u0442\u044C", -1, 1],
+    ["\u044E\u0442\u044C", -1, 1],
+    ["\u0430\u044E\u0442\u044C", 26, 1],
+    ["\u044E", -1, 1],
+    ["\u0430\u044E", 28, 1],
+    ["\u0456\u044E", 28, 1],
+    ["\u0454", -1, 1]
+];
+
+const a_4 = [
+    ["\u0430", -1, 1],
+    ["\u0435\u0432", -1, 1],
+    ["\u0456\u0432", -1, 1],
+    ["\u0435", -1, 1],
+    ["\u0438", -1, 1],
+    ["\u0430\u043C\u0438", 4, 1],
+    ["\u044F\u043C\u0438", 4, 1],
+    ["\u0435\u0439", -1, 1],
+    ["\u0430\u043C", -1, 1],
+    ["\u0435\u043C", -1, 1],
+    ["\u043E\u043C", -1, 1],
+    ["\u044F\u043C", -1, 1],
+    ["\u0454\u043C", -1, 1],
+    ["\u043E", -1, 1],
+    ["\u0442\u0432\u043E", 13, 1],
+    ["\u0441\u0442\u0432\u043E", 14, 1],
+    ["\u0443", -1, 1],
+    ["\u0430\u0445", -1, 1],
+    ["\u044F\u0445", -1, 1],
+    ["\u044E", -1, 1],
+    ["\u0435\u044E", 19, 1],
+    ["\u043E\u044E", 19, 1],
+    ["\u0454\u044E", 19, 1],
+    ["\u044F", -1, 1],
+    ["\u0454", -1, 1],
+    ["\u0456", -1, 1],
+    ["\u0435\u0432\u0456", 25, 1],
+    ["\u043E\u0432\u0456", 25, 1],
+    ["\u0457", -1, 1]
+];
+
+const a_5 = [
+    ["\u043D\u0438\u043A", -1, 1],
+    ["\u0456\u0432\u043D\u0438\u043A", 0, 1],
+    ["\u0430\u043B\u044C\u043D\u0438\u043A", 0, 1],
+    ["\u0435\u043B\u044C\u043D\u0438\u043A", 0, 1],
+    ["\u0430\u0440", -1, 1],
+    ["\u044F\u0440", -1, 1],
+    ["\u0430\u0447", -1, 1]
+];
+
+const a_6 = [
+    ["\u0438\u043D\u043A\u0430", -1, 1],
+    ["\u0456\u043D\u043A\u0430", -1, 1],
+    ["\u0435\u0447\u043A\u0430", -1, 1],
+    ["\u043E\u0447\u0435\u0447\u043A\u0430", 2, 1],
+    ["\u043E\u0447\u043A\u0430", -1, 1],
+    ["\u0456\u0447\u043A\u0430", -1, 1],
+    ["\u0435\u043D\u044C\u043A\u0430", -1, 1],
+    ["\u0435\u0441\u0435\u043D\u044C\u043A\u0430", 6, 1],
+    ["\u043E\u043D\u044C\u043A\u0430", -1, 1],
+    ["\u0456\u043D\u044C\u043A\u0430", -1, 1],
+    ["\u044E\u0441\u0456\u043D\u044C\u043A\u0430", 9, 1],
+    ["\u0456\u0441\u0456\u043D\u044C\u043A\u0430", 9, 1],
+    ["\u0435\u0447\u043A\u0438", -1, 1],
+    ["\u043E\u0447\u0435\u0447\u043A\u0438", 12, 1],
+    ["\u043E\u0447\u043A\u0438", -1, 1],
+    ["\u0456\u0447\u043A\u0438", -1, 1],
+    ["\u0435\u043D\u044C\u043A\u0438", -1, 1],
+    ["\u0435\u0441\u0435\u043D\u044C\u043A\u0438", 16, 1],
+    ["\u043E\u043D\u044C\u043A\u0438", -1, 1],
+    ["\u0456\u043D\u044C\u043A\u0438", -1, 1],
+    ["\u044E\u0441\u0456\u043D\u044C\u043A\u0438", 19, 1],
+    ["\u0456\u0441\u0456\u043D\u044C\u043A\u0438", 19, 1],
+    ["\u0438\u043A", -1, 1],
+    ["\u0447\u0438\u043A", 22, 1],
+    ["\u043E\u043A", -1, 1],
+    ["\u0435\u0447\u043E\u043A", 24, 1],
+    ["\u043E\u0447\u0435\u0447\u043E\u043A", 25, 1],
+    ["\u043E\u0447\u043E\u043A", 24, 1],
+    ["\u0456\u0447\u043E\u043A", 24, 1],
+    ["\u0456\u043A", -1, 1],
+    ["\u0430\u0442\u043A\u043E", -1, 1],
+    ["\u044F\u0442\u043A\u043E", -1, 1],
+    ["\u0456\u0442\u043A\u043E", -1, 1],
+    ["\u0435\u0447\u043A\u043E", -1, 1],
+    ["\u043E\u0447\u0435\u0447\u043A\u043E", 33, 1],
+    ["\u043E\u0447\u043A\u043E", -1, 1],
+    ["\u0456\u0447\u043A\u043E", -1, 1],
+    ["\u0435\u043D\u044C\u043A\u043E", -1, 1],
+    ["\u0435\u0441\u0435\u043D\u044C\u043A\u043E", 37, 1],
+    ["\u043E\u043D\u044C\u043A\u043E", -1, 1],
+    ["\u0456\u043D\u044C\u043A\u043E", -1, 1],
+    ["\u044E\u0441\u0456\u043D\u044C\u043A\u043E", 40, 1],
+    ["\u0456\u0441\u0456\u043D\u044C\u043A\u043E", 40, 1],
+    ["\u0435\u043D\u044C\u043A\u0443", -1, 1],
+    ["\u0435\u043D\u044C", -1, 1],
+    ["\u0443\u043D\u044C", -1, 1],
+    ["\u0456\u043D\u044C", -1, 1],
+    ["\u043E\u0441\u044C", -1, 1],
+    ["\u0443\u0441\u044C", -1, 1],
+    ["\u0456\u0441\u044C", -1, 1],
+    ["\u0435\u043D\u044F", -1, 1],
+    ["\u0435\u0447\u043A\u0456", -1, 1],
+    ["\u043E\u0447\u0435\u0447\u043A\u0456", 51, 1],
+    ["\u043E\u0447\u043A\u0456", -1, 1],
+    ["\u0456\u0447\u043A\u0456", -1, 1],
+    ["\u0435\u043D\u044C\u043A\u0456", -1, 1],
+    ["\u0435\u0441\u0435\u043D\u044C\u043A\u0456", 55, 1],
+    ["\u043E\u043D\u044C\u043A\u0456", -1, 1],
+    ["\u0456\u043D\u044C\u043A\u0456", -1, 1],
+    ["\u044E\u0441\u0456\u043D\u044C\u043A\u0456", 58, 1],
+    ["\u0456\u0441\u0456\u043D\u044C\u043A\u0456", 58, 1]
+];
+
+const a_7 = [
+    ["\u0430\u0442\u043A", -1, 1],
+    ["\u0456\u0442\u043A", -1, 1],
+    ["\u0435\u043D\u044C\u043A", -1, 1],
+    ["\u0435\u0441\u0435\u043D\u044C\u043A", 2, 1],
+    ["\u043E\u043D\u044C\u043A", -1, 1],
+    ["\u0456\u043D\u044C\u043A", -1, 1],
+    ["\u044E\u0441\u0456\u043D\u044C\u043A", 5, 1],
+    ["\u0456\u0441\u0456\u043D\u044C\u043A", 5, 1],
+    ["\u043E\u0447\u0435\u0447", -1, 1]
+];
+
+const a_8 = [
+    ["\u0430\u043D\u043D\u044F", -1, 1],
+    ["\u0435\u043D\u043D\u044F", -1, 1],
+    ["\u044F\u043D\u043D\u044F", -1, 1],
+    ["\u0456\u043D\u043D\u044F", -1, 1]
+];
+
+const a_9 = [
+    ["\u0456\u0432\u0449\u0438\u043D\u0430", -1, 1],
+    ["\u043E\u0432", -1, 1],
+    ["\u0437\u044C\u043A", -1, 1],
+    ["\u0441\u044C\u043A", -1, 1],
+    ["\u0456\u0437\u043C", -1, 1],
+    ["\u0456\u0432\u043D", -1, 1],
+    ["\u043B\u044C\u043D", -1, 1],
+    ["\u0435\u043B\u044C\u043D", 6, 1],
+    ["\u044F\u043D", -1, 1],
+    ["\u0441\u0442\u0432\u043E", -1, 1],
+    ["\u0446\u0442\u0432\u043E", -1, 1],
+    ["\u043E\u0432\u0430\u0442", -1, 1],
+    ["\u0443\u0432\u0430\u0442", -1, 1],
+    ["\u0456\u0441\u0442", -1, 1],
+    ["\u0438\u0449", -1, 1],
+    ["\u0456\u0441\u0442\u044C", -1, 1],
+    ["\u043E\u0432\u0456\u0441\u0442\u044C", 15, 1],
+    ["\u043D\u0456\u0441\u0442\u044C", 15, 1],
+    ["\u0456\u0432\u043D\u044F", -1, 1],
+    ["\u0430\u0440\u043D\u044F", -1, 1],
+    ["\u043D\u0438\u0446\u044F", -1, 1],
+    ["\u0430\u0446\u0456\u044F", -1, 1],
+    ["\u0456\u0437\u0430\u0446\u0456\u044F", 21, 1]
+];
+
+const a_10 = [
+    ["\u043B", -1, 2],
+    ["\u043D", -1, 3],
+    ["\u0456\u0448", -1, 1],
+    ["\u044C", -1, 4]
+];
+
+const /** Array<number> */ g_v = [33, 65, 8, 192, 208];
+
+import { BaseStemmer } from './base-stemmer.js'
+
+class UkrainianStemmer extends BaseStemmer {
+
+    #I_p2/** number */ = 0;
+    #I_pV/** number */ = 0;
+
+
+    /** @return {boolean} */
+    #r_mark_regions() {
+        this.#I_pV = this.limit;
+        this.#I_p2 = this.limit;
+        const /** number */ v_1 = this.cursor;
+        // deno-lint-ignore no-unused-labels
+        lab0: {
+            if (!this.go_out_grouping(g_v, 1072, 1111)) break lab0;
+            this.cursor++;
+            this.#I_pV = this.cursor;
+            if (!this.go_in_grouping(g_v, 1072, 1111)) break lab0;
+            this.cursor++;
+            if (!this.go_out_grouping(g_v, 1072, 1111)) break lab0;
+            this.cursor++;
+            if (!this.go_in_grouping(g_v, 1072, 1111)) break lab0;
+            this.cursor++;
+            this.#I_p2 = this.cursor;
+        }
+        this.cursor = v_1;
+        return true;
+    }
+
+    /** @return {boolean} */
+    #r_R2() {
+        return this.#I_p2 <= this.cursor;
+    }
+
+    /** @return {boolean} */
+    #r_perfective_gerund() {
+        let /** number */ a;
+        this.ket = this.cursor;
+        a = this.find_among_b(a_0);
+        if (a === 0) return false;
+        this.bra = this.cursor;
+        switch (a) {
+            case 1: {
+                // deno-lint-ignore no-unused-labels
+                lab0: {
+                    const /** number */ v_1 = this.limit - this.cursor;
+                    // deno-lint-ignore no-unused-labels
+                    lab1: {
+                        if (!(this.eq_s_b("\u0430"))) break lab1;
+                        break lab0;
+                    }
+                    this.cursor = this.limit - v_1;
+                    if (!(this.eq_s_b("\u044F"))) return false;
+                }
+                this.slice_del();
+                break;
+            }
+            case 2: {
+                this.slice_del();
+                break;
+            }
+        }
+        return true;
+    }
+
+    /** @return {boolean} */
+    #r_reflexive() {
+        this.ket = this.cursor;
+        if (this.find_among_b(a_1) === 0) return false;
+        this.bra = this.cursor;
+        this.slice_del();
+        return true;
+    }
+
+    /** @return {boolean} */
+    #r_adjective() {
+        let /** number */ a;
+        this.ket = this.cursor;
+        a = this.find_among_b(a_2);
+        if (a === 0) return false;
+        this.bra = this.cursor;
+        switch (a) {
+            case 1: {
+                if (!this.#r_R2()) return false;
+                this.slice_del();
+                break;
+            }
+            case 2: {
+                this.slice_del();
+                break;
+            }
+        }
+        return true;
+    }
+
+    /** @return {boolean} */
+    #r_verb() {
+        this.ket = this.cursor;
+        if (this.find_among_b(a_3) === 0) return false;
+        this.bra = this.cursor;
+        this.slice_del();
+        return true;
+    }
+
+    /** @return {boolean} */
+    #r_noun() {
+        this.ket = this.cursor;
+        if (this.find_among_b(a_4) === 0) return false;
+        this.bra = this.cursor;
+        this.slice_del();
+        return true;
+    }
+
+    /** @return {boolean} */
+    #r_professional() {
+        this.ket = this.cursor;
+        if (this.find_among_b(a_5) === 0) return false;
+        this.bra = this.cursor;
+        this.slice_del();
+        return true;
+    }
+
+    /** @return {boolean} */
+    #r_diminutive() {
+        this.ket = this.cursor;
+        if (this.find_among_b(a_6) === 0) return false;
+        this.bra = this.cursor;
+        this.slice_del();
+        return true;
+    }
+
+    /** @return {boolean} */
+    #r_diminutive_stem() {
+        this.ket = this.cursor;
+        if (this.find_among_b(a_7) === 0) return false;
+        this.bra = this.cursor;
+        this.slice_del();
+        return true;
+    }
+
+    /** @return {boolean} */
+    #r_verbal_noun() {
+        this.ket = this.cursor;
+        if (this.find_among_b(a_8) === 0) return false;
+        this.bra = this.cursor;
+        if (!this.#r_R2()) return false;
+        this.slice_del();
+        return true;
+    }
+
+    /** @return {boolean} */
+    #r_derivational() {
+        this.ket = this.cursor;
+        if (this.find_among_b(a_9) === 0) return false;
+        this.bra = this.cursor;
+        if (!this.#r_R2()) return false;
+        this.slice_del();
+        return true;
+    }
+
+    /** @return {boolean} */
+    #r_tidy_up() {
+        let /** number */ a;
+        this.ket = this.cursor;
+        a = this.find_among_b(a_10);
+        if (a === 0) return false;
+        this.bra = this.cursor;
+        switch (a) {
+            case 1: {
+                this.slice_del();
+                this.ket = this.cursor;
+                if (!(this.eq_s_b("\u043D"))) return false;
+                this.bra = this.cursor;
+                if (!(this.eq_s_b("\u043D"))) return false;
+                this.slice_del();
+                break;
+            }
+            case 2: {
+                // deno-lint-ignore no-unused-labels
+                lab0: {
+                    const /** number */ v_1 = this.limit - this.cursor;
+                    // deno-lint-ignore no-unused-labels
+                    lab1: {
+                        if (!(this.eq_s_b("\u0431"))) break lab1;
+                        break lab0;
+                    }
+                    this.cursor = this.limit - v_1;
+                    // deno-lint-ignore no-unused-labels
+                    lab2: {
+                        if (!(this.eq_s_b("\u043F"))) break lab2;
+                        break lab0;
+                    }
+                    this.cursor = this.limit - v_1;
+                    // deno-lint-ignore no-unused-labels
+                    lab3: {
+                        if (!(this.eq_s_b("\u0432"))) break lab3;
+                        break lab0;
+                    }
+                    this.cursor = this.limit - v_1;
+                    if (!(this.eq_s_b("\u043C"))) return false;
+                }
+                this.slice_del();
+                break;
+            }
+            case 3: {
+                if (!(this.eq_s_b("\u043D"))) return false;
+                this.slice_del();
+                break;
+            }
+            case 4: {
+                this.slice_del();
+                break;
+            }
+        }
+        return true;
+    }
+
+    /** @return {boolean} */
+    #stem() {
+        let /** boolean */ B_found_professional;
+        let /** boolean */ B_found_diminutive;
+        const /** number */ v_1 = this.cursor;
+        // deno-lint-ignore no-unused-labels
+        lab0: {
+            this.bra = this.cursor;
+            if (!(this.eq_s("\u043D\u0430\u0439"))) break lab0;
+            this.ket = this.cursor;
+            this.slice_del();
+        }
+        this.cursor = v_1;
+        B_found_diminutive = false;
+        B_found_professional = false;
+        this.#r_mark_regions();
+        this.limit_backward = this.cursor; this.cursor = this.limit;
+        if (this.cursor < this.#I_pV) return false;
+        const /** number */ v_2 = this.limit_backward;
+        this.limit_backward = this.#I_pV;
+        const /** number */ v_3 = this.limit - this.cursor;
+        // deno-lint-ignore no-unused-labels
+        lab1: {
+            // deno-lint-ignore no-unused-labels
+            lab2: {
+                const /** number */ v_4 = this.limit - this.cursor;
+                // deno-lint-ignore no-unused-labels
+                lab3: {
+                    if (!this.#r_perfective_gerund()) break lab3;
+                    break lab2;
+                }
+                this.cursor = this.limit - v_4;
+                const /** number */ v_5 = this.limit - this.cursor;
+                // deno-lint-ignore no-unused-labels
+                lab4: {
+                    if (!this.#r_reflexive()) {
+                        this.cursor = this.limit - v_5;
+                        break lab4;
+                    }
+                }
+                // deno-lint-ignore no-unused-labels
+                lab5: {
+                    const /** number */ v_6 = this.limit - this.cursor;
+                    // deno-lint-ignore no-unused-labels
+                    lab6: {
+                        if (!this.#r_verbal_noun()) break lab6;
+                        break lab5;
+                    }
+                    this.cursor = this.limit - v_6;
+                    const /** number */ v_7 = this.limit - this.cursor;
+                    // deno-lint-ignore no-unused-labels
+                    lab7: {
+                        // deno-lint-ignore no-unused-labels
+                        lab8: {
+                            const /** number */ v_8 = this.limit - this.cursor;
+                            // deno-lint-ignore no-unused-labels
+                            lab9: {
+                                if (!this.#r_professional()) break lab9;
+                                B_found_professional = true;
+                                break lab8;
+                            }
+                            this.cursor = this.limit - v_8;
+                            if (!this.#r_diminutive()) {
+                                this.cursor = this.limit - v_7;
+                                break lab7;
+                            }
+                            B_found_diminutive = true;
+                        }
+                    }
+                    if (B_found_professional) break lab1;
+                    // deno-lint-ignore no-unused-labels
+                    lab10: {
+                        const /** number */ v_9 = this.limit - this.cursor;
+                        // deno-lint-ignore no-unused-labels
+                        lab11: {
+                            if (!this.#r_adjective()) break lab11;
+                            break lab10;
+                        }
+                        this.cursor = this.limit - v_9;
+                        // deno-lint-ignore no-unused-labels
+                        lab12: {
+                            if (!this.#r_verb()) break lab12;
+                            break lab10;
+                        }
+                        this.cursor = this.limit - v_9;
+                        if (!this.#r_noun()) break lab1;
+                    }
+                }
+            }
+        }
+        this.cursor = this.limit - v_3;
+        const /** number */ v_10 = this.limit - this.cursor;
+        // deno-lint-ignore no-unused-labels
+        lab13: {
+            if (!this.#r_diminutive_stem()) {
+                this.cursor = this.limit - v_10;
+                break lab13;
+            }
+            B_found_diminutive = true;
+        }
+        if (B_found_diminutive) {
+            this.limit_backward = v_2;
+            return false;
+        }
+        if (B_found_professional) {
+            this.limit_backward = v_2;
+            return false;
+        }
+        const /** number */ v_11 = this.limit - this.cursor;
+        // deno-lint-ignore no-unused-labels
+        lab14: {
+            if (!this.#r_professional()) {
+                this.cursor = this.limit - v_11;
+                break lab14;
+            }
+        }
+        const /** number */ v_12 = this.limit - this.cursor;
+        this.#r_derivational();
+        this.cursor = this.limit - v_12;
+        const /** number */ v_13 = this.limit - this.cursor;
+        this.#r_tidy_up();
+        this.cursor = this.limit - v_13;
+        this.limit_backward = v_2;
+        this.cursor = this.limit_backward;
+        return true;
+    }
+
+    /**@return{string}*/
+    stem(/**string*/input) {
+        this.setCurrent(input);
+        this.#stem();
+        return this.getCurrent();
+    }
+
+    stemWord = this.stem;
+}
+
+export { UkrainianStemmer };


### PR DESCRIPTION
Add documentation and web demo for the Ukrainian stemmer (companion to
snowballstem/snowball#277).

- algorithms/ukrainian/stemmer.tt — algorithm description with design notes
- algorithms/index.tt — add Ukrainian to the Slavic stemmers list
- index.tt — site news entry
- js/ukrainian-stemmer.js — auto-generated JS implementation for demo
- code/ukrainian.sbl — copy of the algorithm source for syntax highlighting